### PR TITLE
Create pages navigation and projects page

### DIFF
--- a/pages/about.js
+++ b/pages/about.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function About() {
+  return <div>Página sobre</div>;
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,7 +3,6 @@ import About from '../src/components/commons/About';
 import Footer from '../src/components/commons/Footer';
 import Header from '../src/components/commons/Header';
 import Main from '../src/components/commons/Main';
-import Projects from '../src/components/commons/Projects';
 import Box from '../src/components/foundation/layout/Box';
 
 export default function Home() {
@@ -31,7 +30,6 @@ export default function Home() {
         <Header />
         <Main />
         <About />
-        <Projects />
         <Footer />
       </Box>
     </Box>

--- a/pages/projects/index.js
+++ b/pages/projects/index.js
@@ -2,11 +2,24 @@ import React from 'react';
 import Header from '../../src/components/commons/Header';
 import ProjectsScreen from '../../src/components/screens/ProjectsScreen';
 
-export default function Projects() {
+// eslint-disable-next-line react/prop-types
+export default function Projects({ githubProjects }) {
   return (
     <>
       <Header />
-      <ProjectsScreen />
+      <ProjectsScreen githubProjects={githubProjects} />
     </>
   );
+}
+
+export async function getStaticProps() {
+  const githubProjects = await fetch(
+    'https://api.github.com/users/guijun13/repos'
+  ).then(serverResponse => serverResponse.json());
+
+  return {
+    props: {
+      githubProjects,
+    },
+  };
 }

--- a/pages/projects/index.js
+++ b/pages/projects/index.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Projects() {
+  return <div>Página projetos</div>;
+}

--- a/pages/projects/index.js
+++ b/pages/projects/index.js
@@ -1,5 +1,12 @@
 import React from 'react';
+import Header from '../../src/components/commons/Header';
+import ProjectsScreen from '../../src/components/screens/ProjectsScreen';
 
 export default function Projects() {
-  return <div>Página projetos</div>;
+  return (
+    <>
+      <Header />
+      <ProjectsScreen />
+    </>
+  );
 }

--- a/src/components/commons/Button/index.js
+++ b/src/components/commons/Button/index.js
@@ -1,8 +1,11 @@
+import React from 'react';
+import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import get from 'lodash/get';
 import { TextStyleVariantsMap } from '../../foundation/Text';
 import breakpointsMedia from '../../../theme/utils/breakpointsMedia';
 import propToStyle from '../../../theme/utils/propToStyle';
+import Link from '../Link';
 
 const ButtonGhost = css`
   color: ${props => get(props.theme, `colors.${props.variant}.color`)};
@@ -15,7 +18,7 @@ const ButtonDefault = css`
   color: ${props => get(props.theme, `colors.${props.variant}.contrastText`)};
 `;
 
-const Button = styled.button`
+const ButtonWrapper = styled.button`
   border: 0;
   cursor: pointer;
   padding: 12px 26px;
@@ -34,10 +37,10 @@ const Button = styled.button`
 
   ${breakpointsMedia({
     xs: css`
-      ${TextStyleVariantsMap.smallestException}
+      ${TextStyleVariantsMap.small}
     `,
     md: css`
-      ${TextStyleVariantsMap.paragraph1}
+      ${TextStyleVariantsMap.titleh1}
     `,
   })}
 
@@ -56,4 +59,22 @@ const Button = styled.button`
   ${propToStyle('flex')}
 `;
 
-export default Button;
+export default function Button({ href, children, ...props }) {
+  const hasHref = Boolean(href); // verifica se href é booleano
+  const tag = hasHref ? Link : 'button';
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <ButtonWrapper as={tag} href={href} {...props}>
+      {children}
+    </ButtonWrapper>
+  );
+}
+
+Button.defaultProps = {
+  href: undefined,
+};
+
+Button.propTypes = {
+  href: PropTypes.string,
+  children: PropTypes.node.isRequired,
+};

--- a/src/components/commons/Header/index.js
+++ b/src/components/commons/Header/index.js
@@ -6,12 +6,15 @@ import HeaderWrapper from './styles/HeaderWrapper';
 const links = [
   {
     text: 'Sobre',
+    url: '/about',
   },
   {
     text: 'Projetos',
+    url: '/projects',
   },
   {
     text: 'Contato',
+    url: '/',
   },
 ];
 
@@ -24,7 +27,7 @@ export default function Header() {
       <HeaderWrapper.RightSide>
         {links.map(link => (
           <li key={link.text}>
-            <Text tag="a" variant="regular">
+            <Text tag="a" variant="regular" href={link.url}>
               {link.text}
             </Text>
           </li>

--- a/src/components/commons/Link/index.js
+++ b/src/components/commons/Link/index.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import styled from 'styled-components';
+import get from 'lodash';
+import PropTypes from 'prop-types';
+import NextLink from 'next/link';
+
+const StyledLink = styled.a`
+  color: inherit;
+  ${({ theme, color }) =>
+    color
+      ? `color: ${get(theme, `colors.${color}.color`)}`
+      : 'color: inherit;'};
+  text-decoration: none;
+  opacity: 1;
+  transition: opacity ${({ theme }) => theme.transition};
+  &:hover,
+  &:focus {
+    opacity: 0.5;
+  }
+`;
+
+export default function Link({ href, children, ...props }) {
+  return (
+    <NextLink href={href} passHref>
+      {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+      <StyledLink {...props}>{children}</StyledLink>
+    </NextLink>
+  );
+}
+
+Link.propTypes = {
+  href: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+};

--- a/src/components/foundation/Text/index.js
+++ b/src/components/foundation/Text/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import get from 'lodash/get';
 import styled, { css } from 'styled-components';
 import propToStyle from '../../../theme/utils/propToStyle';
+import Link from '../../commons/Link';
 
 export const TextStyleVariantsMap = {
   titleh1: css`
@@ -56,7 +57,20 @@ const TextBase = styled.span`
   ${propToStyle('margin')};
 `;
 
-export default function Text({ tag, variant, children, ...props }) {
+export default function Text({ tag, variant, children, href, ...props }) {
+  if (href) {
+    return (
+      <TextBase
+        as={Link}
+        href={href}
+        variant={variant}
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...props}
+      >
+        {children}
+      </TextBase>
+    );
+  }
   return (
     // eslint-disable-next-line react/jsx-props-no-spreading
     <TextBase as={tag} variant={variant} {...props}>
@@ -69,9 +83,11 @@ Text.propTypes = {
   tag: PropTypes.string,
   variant: PropTypes.string,
   children: PropTypes.node.isRequired,
+  href: PropTypes.string,
 };
 
 Text.defaultProps = {
   tag: 'span',
   variant: 'regular',
+  href: '',
 };

--- a/src/components/screens/ProjectsScreen/ProjectsScreenWrapper/index.js
+++ b/src/components/screens/ProjectsScreen/ProjectsScreenWrapper/index.js
@@ -23,7 +23,7 @@ export const LanguageBox = styled.div`
 `;
 
 // eslint-disable-next-line react/prop-types
-export default function ProjectWrapper({ project }) {
+export default function ProjectsScreenWrapper({ project }) {
   return (
     <ProjectCard>
       <img
@@ -50,6 +50,6 @@ export default function ProjectWrapper({ project }) {
   );
 }
 
-ProjectWrapper.propTypes = {
+ProjectsScreenWrapper.propTypes = {
   project: PropTypes.string.isRequired,
 };

--- a/src/components/screens/ProjectsScreen/ProjectsScreenWrapper/index.js
+++ b/src/components/screens/ProjectsScreen/ProjectsScreenWrapper/index.js
@@ -28,28 +28,29 @@ export default function ProjectsScreenWrapper({ project }) {
     <ProjectCard>
       <img
         style={{ display: 'block', margin: 'auto', marginBottom: '20px' }}
-        src={project.image}
+        src="https://placehold.it/300x150.png"
         alt="img"
       />
       <Text marginBottom="20px" textAlign="center" tag="h5" variant="titleh5">
-        {project.title}
+        /{project.name}
       </Text>
       <Text margin="0 20px" textAlign="center" tag="p" variant="small">
-        {project.description}
+        {project.description != null
+          ? project.description
+          : 'Repo sem descrição'}
       </Text>
       <LanguageContainer>
-        {project.languages.map(lang => (
-          <LanguageBox key={lang}>
-            <Text textAlign="center" tag="p" variant="regular">
-              {lang}
-            </Text>
-          </LanguageBox>
-        ))}
+        <LanguageBox>
+          <Text textAlign="center" tag="p" variant="regular">
+            {project.language != null ? project.language : '?'}
+          </Text>
+        </LanguageBox>
       </LanguageContainer>
     </ProjectCard>
   );
 }
 
 ProjectsScreenWrapper.propTypes = {
-  project: PropTypes.string.isRequired,
+  // eslint-disable-next-line react/forbid-prop-types
+  project: PropTypes.object.isRequired,
 };

--- a/src/components/screens/ProjectsScreen/index.js
+++ b/src/components/screens/ProjectsScreen/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from 'react';
 import CardContainer from '../../../theme/utils/CardContainer';
 import Box from '../../foundation/layout/Box';
@@ -5,40 +6,7 @@ import Grid from '../../foundation/layout/Grid';
 import Text from '../../foundation/Text';
 import ProjectsScreenWrapper from './ProjectsScreenWrapper';
 
-const projects = [
-  {
-    image: 'https://placehold.it/300x150.png',
-    url: 'https://github.com/guijun13/instadev',
-    title: '/instadev',
-    description: 'Projeto principal do Bootcamp Front-End JAMStack da Alura',
-    languages: ['Javascript', 'Next.js'],
-  },
-  {
-    image: 'https://placehold.it/300x150.png',
-    url: 'https://github.com/guijun13/ux-quiz',
-    title: '/ux-quiz',
-    description:
-      'Projeto de quiz criado durante a Imersão React Nextjs v2 por Alura',
-    languages: ['Javascript', 'Next.js'],
-  },
-  {
-    image: 'https://placehold.it/300x150.png',
-    url: 'https://github.com/guijun13/guijunflix',
-    title: '/guijunflix',
-    description: 'Projeto da ImersãoReact da Alura',
-    languages: ['Javascript', 'CSS'],
-  },
-  {
-    image: 'https://placehold.it/300x150.png',
-    url: 'https://github.com/guijun13/CacheSite',
-    title: '/CacheSite',
-    description:
-      'Site estático sobre memória cache: definição e funções de mapeamento',
-    languages: ['Javascript'],
-  },
-];
-
-export default function ProjectsScreen() {
+export default function ProjectsScreen({ githubProjects }) {
   return (
     <Box>
       <Grid.Container
@@ -54,9 +22,9 @@ export default function ProjectsScreen() {
             </Text>
           </Grid.Row>
           <Grid.Row>
-            {projects.map(project => (
+            {githubProjects.map(project => (
               <Grid.Col
-                key={project.title}
+                key={project.full_name}
                 value={{ md: 6, xs: 12 }} // ocupa colunas
                 offset={{ md: 0, xs: 0 }} // desloca/pula colunas
                 display="flex"

--- a/src/components/screens/ProjectsScreen/index.js
+++ b/src/components/screens/ProjectsScreen/index.js
@@ -1,8 +1,9 @@
 import React from 'react';
+import CardContainer from '../../../theme/utils/CardContainer';
+import Box from '../../foundation/layout/Box';
 import Grid from '../../foundation/layout/Grid';
 import Text from '../../foundation/Text';
-import CardContainer from '../../../theme/utils/CardContainer';
-import ProjectWrapper from './ProjectWrapper';
+import ProjectsScreenWrapper from './ProjectsScreenWrapper';
 
 const projects = [
   {
@@ -37,36 +38,38 @@ const projects = [
   },
 ];
 
-export default function Projects() {
+export default function ProjectsScreen() {
   return (
-    <Grid.Container
-      marginBottom={{
-        xs: '40px',
-        md: '130px',
-      }}
-    >
-      <CardContainer>
-        <Grid.Row>
-          <Text margin="20px" tag="h3" variant="titleh3">
-            Projetos
-          </Text>
-        </Grid.Row>
-        <Grid.Row>
-          {projects.map(project => (
-            <Grid.Col
-              key={project.title}
-              value={{ md: 6, xs: 12 }} // ocupa colunas
-              offset={{ md: 0, xs: 0 }} // desloca/pula colunas
-              display="flex"
-              alignItems="center"
-              justifyContent="center"
-              flexDirection="column"
-            >
-              <ProjectWrapper project={project} />
-            </Grid.Col>
-          ))}
-        </Grid.Row>
-      </CardContainer>
-    </Grid.Container>
+    <Box>
+      <Grid.Container
+        marginBottom={{
+          xs: '40px',
+          md: '130px',
+        }}
+      >
+        <CardContainer>
+          <Grid.Row>
+            <Text margin="20px" tag="h3" variant="titleh3">
+              Projetos
+            </Text>
+          </Grid.Row>
+          <Grid.Row>
+            {projects.map(project => (
+              <Grid.Col
+                key={project.title}
+                value={{ md: 6, xs: 12 }} // ocupa colunas
+                offset={{ md: 0, xs: 0 }} // desloca/pula colunas
+                display="flex"
+                alignItems="center"
+                justifyContent="center"
+                flexDirection="column"
+              >
+                <ProjectsScreenWrapper project={project} />
+              </Grid.Col>
+            ))}
+          </Grid.Row>
+        </CardContainer>
+      </Grid.Container>
+    </Box>
   );
 }


### PR DESCRIPTION
- Initialize pages navigation using NextJs link component
- Change 'Text' and 'Button' to handle url links
- Create 'Projects' and 'About' pages
- Fill 'Projects' page with github repos infos
- Remove old 'projects' section from 'Home' page