### PR TITLE
Create repository slug page

### DIFF
--- a/pages/projects/[slug].js
+++ b/pages/projects/[slug].js
@@ -1,0 +1,53 @@
+import React from 'react';
+import RespositoryScreen from '../../src/components/screens/ProjectsScreen/RepositoryScreen';
+
+// eslint-disable-next-line react/prop-types
+export default function ProjectsRepoScreen({ repoName, repoDescription }) {
+  console.log(repoName);
+  console.log(repoDescription);
+  return (
+    <RespositoryScreen repoName={repoName} repoDescription={repoDescription} />
+  );
+}
+
+export async function getStaticProps({ params }) {
+  const githubProjects = await fetch(
+    'https://api.github.com/users/guijun13/repos'
+  ).then(async serverResponse => {
+    const response = await serverResponse.json();
+    return response;
+  });
+
+  const pageData = githubProjects.find(repository => {
+    if (repository.name === params.slug) {
+      return true;
+    }
+    return false;
+  });
+
+  return {
+    props: {
+      repoName: pageData.name,
+      repoDescription: pageData.description,
+    },
+  };
+}
+
+export async function getStaticPaths() {
+  const githubProjects = await fetch(
+    'https://api.github.com/users/guijun13/repos'
+  ).then(async serverResponse => {
+    const response = await serverResponse.json();
+    return response;
+  });
+
+  const paths = githubProjects.map(repository => {
+    const repoSlug = repository.name;
+    return { params: { slug: repoSlug } };
+  });
+
+  return {
+    paths,
+    fallback: false,
+  };
+}

--- a/src/components/screens/ProjectsScreen/ProjectsScreenWrapper/index.js
+++ b/src/components/screens/ProjectsScreen/ProjectsScreenWrapper/index.js
@@ -31,7 +31,13 @@ export default function ProjectsScreenWrapper({ project }) {
         src="https://placehold.it/300x150.png"
         alt="img"
       />
-      <Text marginBottom="20px" textAlign="center" tag="h5" variant="titleh5">
+      <Text
+        marginBottom="20px"
+        textAlign="center"
+        tag="h5"
+        variant="titleh5"
+        href={`/projects/${project.name}`}
+      >
         /{project.name}
       </Text>
       <Text margin="0 20px" textAlign="center" tag="p" variant="small">

--- a/src/components/screens/ProjectsScreen/RepositoryScreen/index.js
+++ b/src/components/screens/ProjectsScreen/RepositoryScreen/index.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import Header from '../../../commons/Header';
+import Box from '../../../foundation/layout/Box';
+import Grid from '../../../foundation/layout/Grid';
+import Text from '../../../foundation/Text';
+
+// eslint-disable-next-line react/prop-types
+export default function RespositoryScreen({ repoName, repoDescription }) {
+  return (
+    <>
+      <Header />
+      <Grid.Container>
+        <Box display="flex" flexDirection="column" padding="100px">
+          <Text tag="h1" variant="titleh1" textAlign="center">
+            {repoName}
+          </Text>
+          <Text tag="p" variant="regular" textAlign="center">
+            {repoDescription}
+          </Text>
+        </Box>
+      </Grid.Container>
+    </>
+  );
+}


### PR DESCRIPTION
- Create page to be the base to a repository slug
- Create slug.js to handle functions such as getStaticProps and getStaticPaths
- Add href on 'ProjectsScreen' title to redirect to a specific repository